### PR TITLE
Make kafka HA

### DIFF
--- a/kubernetes/kafka/kafka-ha.yml
+++ b/kubernetes/kafka/kafka-ha.yml
@@ -1,0 +1,128 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-headless
+  namespace: openwhisk
+  labels:
+    app: kafka-headless
+spec:
+  ports:
+    - port: 9092
+      targetPort: 9092
+      name: kafka
+  clusterIP: None
+  selector:
+    app: kafka
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kafka-budget
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  minAvailable: 2
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: kafka
+  namespace: openwhisk
+spec:
+  serviceName: kafka-headless
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: kafka
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - kafka-headless
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: kafka
+        imagePullPolicy: IfNotPresent
+        image: danlavine/whisk_kafka
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 100m
+        ports:
+        - name: kafka
+          containerPort: 9092
+        env:
+        - name: "KAFKA_ADVERTISED_HOST_NAME"
+          value: kafka.openwhisk
+        - name: "KAFKA_PORT"
+          value: "9092"
+        - name: "KAFKA_BROKER_ID"
+        
+        # message settings
+        - name: "REPLICATION_FACTOR"
+          value: "1"
+        - name: "PARTITIONS"
+          value: "1"
+
+        # health topic settings
+        - name: "KAFKA_TOPICS_HEALTH_RETENTIONBYTES"
+          value: "536870912"
+        - name: "KAFKA_TOPICS_HEALTH_RETENTIONMS"
+          value: "1073741824"
+        - name: "KAFKA_TOPICS_HEALTH_SEGMENTBYTES"
+          value: "3600000"
+
+        # complete topic settings
+        - name: "CONTROLLER_COUNT"
+          value: "2"
+        - name: "KAFKA_TOPICS_COMPLETED_RETENTIONBYTES"
+          value: "536870912"
+        - name: "KAFKA_TOPICS_COMPLETED_RETENTIONMS"
+          value: "1073741824"
+        - name: "KAFKA_TOPICS_COMPLETED_SEGMENTBYTES"
+          value: "3600000"
+
+        # invoker topic settings
+        - name: "INVOKER_COUNT"
+          value: "1"
+        - name: "KAFKA_TOPICS_INVOKER_RETENTIONBYTES"
+          value: "536870912"
+        - name: "KAFKA_TOPICS_INVOKER_RETENTIONMS"
+          value: "1073741824"
+        - name: "KAFKA_TOPICS_INVOKER_SEGMENTBYTES"
+          value: "3600000"
+
+        # zookeeper info
+        - name: "ZOOKEEPER_HOST"
+          value: "zookeeper.openwhisk"
+        - name: "ZOOKEEPER_PORT"
+          value: "2181"
+        command:
+        - sh
+        - -c
+        - export KAFKA_BROKER_ID=$(expr $(hostname | grep -o "[[:digit:]]*$") + 1) && /init.sh
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/kafka/data
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 200Gi

--- a/kubernetes/zookeeper/zookeeper-ha.yml
+++ b/kubernetes/zookeeper/zookeeper-ha.yml
@@ -10,9 +10,6 @@ spec:
   selector:
     app: zookeeper
   ports:
-    - port: 2181
-      targetPort: 2181
-      name: zookeeper
     - port: 2888
       targetPort: 2888
       name: server
@@ -20,6 +17,21 @@ spec:
       targetPort: 3888
       name: leader-election
   clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  namespace: openwhisk
+  labels:
+    app: zookeeper
+spec:
+  selector:
+    app: zookeeper
+  ports:
+    - port: 2181
+      targetPort: 2181
+      name: zookeeper
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
In addition to providing an HA version of kafka using statefulset, I also fixed a minor issue with the zookeeper-ha.yml file that was preventing us from connecting kafka to zookeeper because the client port was in the headless service.  Now there are 2 zookeeper services.  The headless one is used by zookeeper to do the election stuff and the other service is used for clients like kafka to connect to it.