### PR TITLE
How to run OW on GKE

### DIFF
--- a/resources/gke/README.md
+++ b/resources/gke/README.md
@@ -1,0 +1,217 @@
+# Deploying OpenWhisk to Google Container Engine (GKE)
+
+Although, you probably would not choose to deploy OpenWhisk to GKE for a production environment, it is often useful for testing OpenWhisk or your FaaS functions.
+
+## Preparing a GKE Kubernetes container cluster
+
+### Set up gcloud configuration
+
+Before proceeding make sure you have a Google Cloud Platform project umbrella to work under and the correct `gcloud` configuration setup so that any subsequent commands you run will default to the correct project, zone, etc. This can easily be done by running the `gcloud init` command. See [https://cloud.google.com/sdk/docs/initializing](https://cloud.google.com/sdk/docs/initializing) for more details. Here's an example of what it should look like to match the commands in the rest of this demo:
+
+```
+gcloud config list
+Your active configuration is: [default]
+
+[compute]
+region = us-west1
+zone = us-west1-a
+[core]
+account = you@example.com
+project = openwhisk-gke
+```
+If it doesn't match this, then make sure you make the appropriate changes in the `gcloud container create` command below. Otherwise, run `gcloud init` or the commands below to set it up correctly:
+
+```
+gcloud config configurations activate default
+gcloud config set compute/region us-west1
+Updated property [compute/region].
+gcloud config set compute/zone us-west1-a
+Updated property [compute/zone].
+gcloud config set core/account you@example.com
+Updated property [core/account].
+gcloud config set project openwhisk-gke
+Updated property [core/project].
+```
+
+### Create GKE Kubernetes container cluster
+
+Now we need to set up a GKE Kubernetes container cluster. We will start with a 4 node cluster.  You may adjust the options in the command below to your specific use case.
+
+```
+gcloud beta container --project "openwhisk-gke" clusters create "openwhisk-cluster" --zone "us-west1-a" --username="admin" --cluster-version "1.7.5" --machine-type "n1-standard-2" --image-type "COS" --disk-size "100" --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring.write","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "4" --network "default" --enable-cloud-logging --no-enable-cloud-monitoring --enable-legacy-authorization
+
+Creating cluster openwhisk-cluster...done.                                               
+Created [https://container.googleapis.com/v1/projects/openwhisk-gke/zones/us-west1-a/clusters/openwhisk-cluster].
+kubeconfig entry generated for openwhisk-cluster.
+NAME               ZONE        MASTER_VERSION  MASTER_IP      MACHINE_TYPE   NODE_VERSION  NUM_NODES  STATUS
+openwhisk-cluster  us-west1-a  1.7.5           104.198.5.180  n1-standard-2  1.7.5         4          RUNNING
+```
+
+Then configure `kubectl` on your local machine to access the cluster. If you don't have `kubectl` installed, then install it with `gcloud components install kubectl` or download the right binary version of it to match the version of Kubernetes on the cluster. See [http://kubernetes.io/docs/getting-started-guides/kubectl/](http://kubernetes.io/docs/getting-started-guides/kubectl/) for more details. Once `kubectl` is installed, configure it to access the cluster:
+
+```
+gcloud container clusters get-credentials openwhisk-cluster --zone us-west1-a --project openwhisk-gke
+Fetching cluster endpoint and auth data.
+kubeconfig entry generated for openwhisk-cluster.
+```
+
+Verify the container cluster nodes are ready:
+
+```
+kubectl get nodes
+NAME                                               STATUS    AGE       VERSION
+gke-openwhisk-cluster-default-pool-b9b119ec-0t6b   Ready     14m       v1.7.5
+gke-openwhisk-cluster-default-pool-b9b119ec-14vm   Ready     14m       v1.7.5
+gke-openwhisk-cluster-default-pool-b9b119ec-j0k8   Ready     14m       v1.7.5
+gke-openwhisk-cluster-default-pool-b9b119ec-lnfd   Ready     14m       v1.7.5
+```
+
+Create the namespace:
+
+```
+kubectl create ns openwhisk
+namespace "openwhisk" created
+```
+
+Then, deploy OpenWhisk from this directory:
+
+```
+kubectl -n openwhisk create -f .
+configmap "openwhisk-config" created
+service "controller" created
+configmap "controller" created
+statefulset "controller" created
+job "install-openwhisk-catalog" created
+service "couchdb" created
+deployment "couchdb" created
+secret "openwhisk" created
+secret "couchdb" created
+configmap "invoker" created
+statefulset "invoker" created
+job "preload-openwhisk-runtimes" created
+service "kafka" created
+deployment "kafka" created
+service "nginx" created
+configmap "nginx" created
+deployment "nginx" created
+secret "nginx" created
+service "zookeeper" created
+deployment "zookeeper" created
+```
+
+Wait for the system to stablize.  It will take about 5 mins and some pods may crash and restart.  Use the following command to watch the pods:
+
+```
+kubectl -n openwhisk get pods -w
+```
+
+Make sure all pods enter the Running state before moving on. If not,
+something is broken. Start troubleshooting by looking in the logs of
+the failing pods.
+
+Then, wait until the controller recognizes the invoker as healthy:
+
+```
+kubectl -n openwhisk logs -f controller-0 | grep "invoker status changed"
+```
+
+You're looking for a message like `invoker status changed to 0 -> Healthy`
+
+It may take a while for the EXTERNAL-IP address for nginx to become available.  Use the following command to see when there is a valid EXTERNAL-IP:
+
+```
+kubectl -n openwhisk get service nginx
+NAME      CLUSTER-IP      EXTERNAL-IP     PORT(S)                                     AGE
+nginx     10.11.241.204   35.199.151.15   80:30111/TCP,443:31128/TCP,8443:31044/TCP   50m
+```
+
+To test the system, first make sure you have a `wsk` binary in your
+$PATH (download from
+https://github.com/apache/incubator-openwhisk-cli/releases/), then:
+
+```
+AUTH_SECRET=$(kubectl -n openwhisk get secret openwhisk -o yaml | grep "system:" | awk '{print $2}' | base64 --decode)
+WSK_PORT=$(kubectl -n openwhisk describe service nginx | grep https-api | grep -v NodePort | awk '{print $3}' | cut -d'/' -f1)
+WSK_IP=$(kubectl -n openwhisk describe service nginx | grep Ingress | awk '{print $3}')
+wsk property set --auth $AUTH_SECRET --apihost https://$WSK_IP:$WSK_PORT
+wsk -i list
+wsk -i action invoke /whisk.system/utils/echo -p message hello -b
+```
+
+Without the `-i` option, you will get a certificate validation error
+due to the self-signed cert the nginx service is using.
+
+Assuming that worked, try a more complex example involving triggers
+and rules. First, install the alarms package:
+
+```
+kubectl -n openwhisk create -f packages/alarms.yml
+```
+
+Once the `alarmprovider` pod enters the Running state, try the
+following:
+
+```
+wsk -i trigger create every-5-seconds \
+    --feed  /whisk.system/alarms/alarm \
+    --param cron '*/5 * * * * *' \
+    --param maxTriggers 25 \
+    --param trigger_payload "{\"name\":\"Odin\",\"place\":\"Asgard\"}"
+wsk -i rule create \
+    invoke-periodically \
+    every-5-seconds \
+    /whisk.system/samples/greeting
+wsk -i activation poll
+```
+
+## Sensitive Data
+
+Authentication credentials are stored in Kubernetes
+[secrets](https://kubernetes.io/docs/concepts/configuration/secret/),
+by default in the [insecure-secrets.yml](insecure-secrets.yml)
+resource in this directory. This is convenient for development, but at
+some point you'll want to create your own credentials.
+
+The username and password for CouchDB are set in the `couchdb` secret:
+
+```
+kubectl -n openwhisk create secret generic couchdb \
+    --from-literal=username=YOURUSERNAME --from-literal=password=YOURPASSWORD
+```
+
+The tokens used for authentication between *system* components and
+*guest* users are set in the `openwhisk` secret. OpenWhisk requires
+these tokens to be a specific format: a UUID and a key separated by a
+colon. The key must contain exactly 64 alphanumeric characters. For
+example, here's one way of creating a valid token on Linux:
+
+```
+UUID=$(cat /proc/sys/kernel/random/uuid)
+KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)
+TOKEN="${UUID}:${KEY}"
+```
+
+You'll need one token for the *system* and one for *guest* users. Both
+should be set in the `openwhisk` secret like so:
+
+```
+kubectl -n openwhisk create secret generic openwhisk \
+    --from-literal=system="$(cat /proc/sys/kernel/random/uuid):$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)" \
+    --from-literal=guest="$(cat /proc/sys/kernel/random/uuid):$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)"
+```
+
+## Cleaning Up
+
+You can delete your GKE cluster from the Google Cloud console or use the cli with:
+
+```
+gcloud container clusters delete openwhisk-cluster --project "openwhisk-gke" --zone "us-west1-a"
+The following clusters will be deleted.
+ - [openwhisk-cluster] in [us-west1-a]
+
+Do you want to continue (Y/n)?  Y
+
+Deleting cluster openwhisk-cluster...done.
+```
+
+If your cluster was using persistent volumes (which it is for the stateful sets) these may not be deleted automatically when you delete the cluster above.  Using the Google Cloud console, navigate to the Compute Engine->Disks and verify that no persistent disks are still around (you will get charged a very small amount if you leave these disks around for a while).

--- a/resources/gke/config.yml
+++ b/resources/gke/config.yml
@@ -1,0 +1,1 @@
+../minikube/config.yml

--- a/resources/gke/controller.yml
+++ b/resources/gke/controller.yml
@@ -1,0 +1,1 @@
+../minikube/controller.yml

--- a/resources/gke/couchdb.yml
+++ b/resources/gke/couchdb.yml
@@ -1,0 +1,1 @@
+../minikube/couchdb.yml

--- a/resources/gke/insecure-secrets.yml
+++ b/resources/gke/insecure-secrets.yml
@@ -1,0 +1,1 @@
+../minikube/insecure-secrets.yml

--- a/resources/gke/invoker.yml
+++ b/resources/gke/invoker.yml
@@ -1,0 +1,1 @@
+../minikube/invoker.yml

--- a/resources/gke/kafka.yml
+++ b/resources/gke/kafka.yml
@@ -1,0 +1,1 @@
+../minikube/kafka.yml

--- a/resources/gke/nginx.yml
+++ b/resources/gke/nginx.yml
@@ -1,0 +1,161 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    name: nginx
+spec:
+  type: LoadBalancer
+  selector:
+    name: nginx
+  ports:
+    - port: 80
+      targetPort: 80
+      name: http
+    - port: 443
+      targetPort: 443
+      name: https-api
+    - port: 8443
+      targetPort: 8443
+      name: https-admin
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx
+data:
+  nginx.conf: |
+    events {
+        worker_connections  4096;
+    }
+    
+    http {
+        client_max_body_size 50M;
+    
+        rewrite_log on;
+        log_format combined-upstream '$remote_addr - $remote_user [$time_local] '
+            '$request $status $body_bytes_sent '
+            '$http_referer $http_user_agent $upstream_addr';
+        access_log /logs/nginx_access.log combined-upstream;
+    
+        upstream controllers {
+            # These addresses are for the controller. If there are more
+            # than two invoker instances deployed then you will need to
+            # add additional controller addresses.
+    
+            server controller-0.controller:8080 fail_timeout=60s;
+            server controller-1.controller:8080 backup;
+        }
+    
+        server {
+            listen 443 default ssl;
+    
+            # match namespace, note while OpenWhisk allows a richer character set for a
+            # namespace, not all those characters are permitted in the (sub)domain name;
+            # if namespace does not match, no vanity URL rewriting takes place.
+            server_name ~^(?<namespace>[0-9a-zA-Z-]+)\.localhost$;
+    
+            ssl_session_cache    shared:SSL:1m;
+            ssl_session_timeout  10m;
+            ssl_certificate      /etc/nginx/certs/tls.crt;
+            ssl_certificate_key  /etc/nginx/certs/tls.key;
+            ssl_verify_client off;
+            ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
+            ssl_ciphers RC4:HIGH:!aNULL:!MD5;
+            ssl_prefer_server_ciphers on;
+            proxy_ssl_session_reuse off;
+    
+            # proxy to the web action path
+            location / {
+                if ($namespace) {
+                  rewrite    /(.*) /api/v1/web/${namespace}/$1 break;
+                }
+                proxy_pass http://controllers;
+                proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
+            }
+    
+            # proxy to 'public/html' web action by convention
+            location = / {
+                if ($namespace) {
+                  rewrite    ^ /api/v1/web/${namespace}/public/index.html break;
+                }
+                proxy_pass http://controllers;
+                proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
+            }
+    
+            location /blackbox-0.1.0.tar.gz {
+                root /etc/nginx;
+            }
+    
+            location /OpenWhiskIOSStarterApp.zip {
+                return 301 https://github.com/openwhisk/openwhisk-client-swift/releases/download/0.2.3/starterapp-0.2.3.zip;
+            }
+    
+            location /cli/go/download {
+                autoindex on;
+                root /etc/nginx;
+            }
+        }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    name: nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      restartPolicy: Always
+      volumes:
+      - name: nginx-certs
+        secret:
+          secretName: nginx
+      - name: nginx-conf
+        configMap:
+          name: nginx
+      - name: openwhisk-config
+        configMap:
+          name: openwhisk-config
+      - name: logs
+        emptyDir: {}
+      containers:
+      - name: nginx
+        imagePullPolicy: IfNotPresent
+        image: projectodd/whisk_nginx:openshift-latest
+        ports:
+        - name: http
+          containerPort: 80
+        - name: http-api
+          containerPort: 443
+        - name: https-admin
+          containerPort: 8443
+        volumeMounts:
+        - name: nginx-conf
+          mountPath: "/etc/nginx/nginx.conf"
+          subPath: "nginx.conf"
+        - name: nginx-certs
+          mountPath: "/etc/nginx/certs"
+        - name: logs
+          mountPath: "/logs"
+        - name: openwhisk-config
+          mountPath: "/openwhisk_config"
+      initContainers:
+      - name: wait-for-controller
+        image: busybox
+        command: ['sh', '-c', 'until wget -T 5 --spider http://controller:8080/ping; do echo waiting for controller; sleep 2; done;']
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMrekNDQWVPZ0F3SUJBZ0lKQU5WVGN1b2VXZ1J0TUEwR0NTcUdTSWIzRFFFQkN3VUFNQlF4RWpBUUJnTlYKQkFNTUNXeHZZMkZzYUc5emREQWVGdzB4TnpBNE1ESXdOREEwTXpKYUZ3MHhPREE0TURJd05EQTBNekphTUJReApFakFRQmdOVkJBTU1DV3h2WTJGc2FHOXpkRENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DCmdnRUJBS2lFc1hJWWxzRVRCdmNwb3dYZStySHlTYjlzc3h4Q05MZnBGVmRHS0Q2OWNSZXlCMVZ1UW1kN0lvZlQKTk1oYjhGdnVtRlpIS3R3UUdLKytwT0RUVGJiUGt0a3JSazlhMUVTbStGb3dyK2dLMGd1SVhsUFNuM3Q0ME9leQpnV3dpb3haVzhtUTNEaytnZzhLUWtpQVVtelRlRWx6TGJXVEpDVkxNaEdlTHFCcVhzUmV1b1VBbDhHT09mSlRMCnRyU2k2SktELzFTRmo2bjM3TzF6L21rTDJwOHlqTnZjSm5aYVQ4S2lpbGVkR1FYa0JYOWFlRXVrdjdZaWt3REIKL3lRU3VWd1JMT1lNNlQzaVpNNTFrdXBVSDhvYUlLVDJCS3d6R0p3VSsyL2Y3RVRxdmtwdWRPWEZPL2xseUUxSwptR1YrTTlLMElUU2dudURYZENGK1VmVkFpN01DQXdFQUFhTlFNRTR3SFFZRFZSME9CQllFRkNZZXMzSlVZa1B2CkkyeTQxU1l5VlhvVGh5NVpNQjhHQTFVZEl3UVlNQmFBRkNZZXMzSlVZa1B2STJ5NDFTWXlWWG9UaHk1Wk1Bd0cKQTFVZEV3UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFEaStpWWsxL3JMdlZYZ1VzREI1YVJNZgpqMmwwSHhiMFJoSyt0QTdnbHpYQWJhdlBwS0QyV0wyakhNVEhPVVY5dWVOb2pCTnI2b055UEN4Y0tlUEh2VTdKCnZkNDhONzBGMm1zQTcyempESm9ySGEyVFpMQjJPWFhqRm95cHFRSnROZ1RWaStRN2M2aUh6Q3pIVEpzRjdRTEMKRFFwcUU3eTVQa2xQSy8xTzJVT0REcFJKQzNoZ0VsRVJEWFpQaDZSUjRnZVB6SzRhb1ZpNzN5c2ZVOVNPWS9mRwpva0NyVlRpdEtVV2dMbWRKSVZXTEJnU2o4SHltZFUrcWV1c1dlc2d5V2JraW5JSmtEWlhHY2N1aDBTNWtjV0Q0CjdOMk1RL1FPRnc2SGtxWFVUMnpiSDR6cVNFYTBUa2dCd0NZcC9HTlFQWTcvbFJFRnUrWGI5WDV1blcwTVZSQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ29oTEZ5R0piQkV3YjMKS2FNRjN2cXg4a20vYkxNY1FqUzM2UlZYUmlnK3ZYRVhzZ2RWYmtKbmV5S0gwelRJVy9CYjdwaFdSeXJjRUJpdgp2cVRnMDAyMno1TFpLMFpQV3RSRXB2aGFNSy9vQ3RJTGlGNVQwcDk3ZU5EbnNvRnNJcU1XVnZKa053NVBvSVBDCmtKSWdGSnMwM2hKY3kyMWt5UWxTeklSbmk2Z2FsN0VYcnFGQUpmQmpqbnlVeTdhMG91aVNnLzlVaFkrcDkrenQKYy81cEM5cWZNb3piM0NaMldrL0Nvb3BYblJrRjVBVi9XbmhMcEwrMklwTUF3ZjhrRXJsY0VTem1ET2s5NG1UTwpkWkxxVkIvS0dpQ2s5Z1NzTXhpY0ZQdHYzK3hFNnI1S2JuVGx4VHY1WmNoTlNwaGxmalBTdENFMG9KN2cxM1FoCmZsSDFRSXV6QWdNQkFBRUNnZ0VBSHJHMHBHU0lLUGl2UHh1dFh1ZGpZRUFTWUxTSzF5M1Q3bCtkREgxeDNTT2kKVXIrUmlHVUI0VmxUUzh3VGhCOEM0NnZNd1lKSzh6UlhXc050d3FtYU1SOFR6MHlMak82dFZTZlllb3o5clZVegpOdmlLdmRmU1Jxb1YydTN2bHVPa012QjVTL21mT0sreThDQm5EVUxUbGtpUXJhZzc3NnlTYnl0alBuejRqSWNpCitEekVlcnRBbzkzVU4zSGh0RTkyMEt3OGVlWStxa3lLVU10cFR0emdiaGN0NXlOenovWW1WUFZ0ajRPR1M4b2oKaHhobHUxR0tIS3AvNW00TnRyb2I5alFLUTN1NWdFTkJmdU5HaXNNVGxSSnFzeDVTSk56Nk1PMkNhTWFZQXk3TApzM2Exdlp1YkFXbHppMkpwbHlKMGh1RUt1R1VtV2ZmcEQ4a0crczlUNFFLQmdRRFlIMlRRV2o1NTJVNWsvM3MvCmZqWkh2VXArdWlnRjk4dDFHUld1QWRGZzlOajhWRWdwcEF5dktQajVjKzI2NmRwMlBXQnZRK3V5MXdvTSsvd0wKMHFpMG8ybUZaanc3dnc1aGt5VGszV25pcnltVXFqRzdRTllsQW1ic1pZRU5KbXAyYmlzODNCaFlpZTVLSXcyZwpWR0VLa2cyVXd3Qjg3S0NLdnBaUGM3Ylk0d0tCZ1FESG5MTE14UTREelVKQm9nSVpYSEhBU29oZ2xORWVpbDJiCjVQa3h3RW9VNUVpZlY0Z1dEZkgyRDFkZndnNVZrVHJnNERwUCtyaUd2b2NicGZ1MldocUE3ZTB4ZzVjQ2pOdm8KNzVneFhQQWJoSW9WUTgrbHd2ZVRWT05Id2tUeXJzQWdzYy94VXVKaUFrYVkyT1VLa0IyZVo0cVIvUzFMam5ncgp4SnlzNER5SzhRS0JnUUM4RkMzK3A5cGczYnk4WmgwU3R6cHptZ2FmWEUrQ1NnKzBPdjFEN2U4UmltTGV6RlgwCmJ3QmUyckE1SGlzUGszMTdrcFErb0FRWkljeHNXa29RMitYWE5iS1oxY3VyVHV3ci9BcUtaU2xGalp3STlVZk0KSm5OMXg2NWNJVVY2ZFNrSElYN2RPc2l4SEcvVDhzZGo5S3B5c1lIQ0tTVmVrZXB3YzhXSkpURkZjd0tCZ0JjVAo5ZFFZNEVMdVF6L0ZWRXJNVmxadUI1QnJCRFpzdHQva1BDOVZWUHRQWFZvV3k2UUpIclZkRnJQNmdwKy85N2V5CkZPdlVSK3RFTWVpdmF3ZXRLUzFJMU1pSnR6YlRSRVdORmVKM0pVZDVMbUhCQWt2ZTI3TEwrSzcrTmV4ODZiZWQKOXpXbWFJZitUVjAwamw2SFJQVmdjVFBwdW9mbXc5d0RrajJtZXpseEFvR0FBY3VGWXhOZDJLYmNjOHVVNHR0VAp1dUVuNXJNeVcxTERRb29FSmhBQ2RwdEFpMFhSY3d0RmtNdHZWSnQvaytUS3VCN3MwaW50eWI1Q1hpbnluNjd3Ci8wTm5PSWJFYUlHNnFRR29id0YzcUhIdHBObWN2QVJ6bzJTK2NwZkl2WERXamlvdEc1NVM2NmozTE1UZWpKOXEKQnhDZWZTWWttUmVCZlNZbUUzMGwzTmc9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: nginx
+type: kubernetes.io/tls

--- a/resources/gke/packages
+++ b/resources/gke/packages
@@ -1,0 +1,1 @@
+../minikube/packages

--- a/resources/gke/zookeeper.yml
+++ b/resources/gke/zookeeper.yml
@@ -1,0 +1,1 @@
+../minikube/zookeeper.yml


### PR DESCRIPTION
Sometime it may be useful to test OW on something other than minikube or minishift since you may want to test a larger configuration.  This describes how to setup OW on Google's Container Engine (GKE) which is a native Kubernetes platform similar to OpenShift.