### PR TITLE
Making probes more conservative

### DIFF
--- a/openshift/controller.yml
+++ b/openshift/controller.yml
@@ -181,17 +181,19 @@ spec:
             path: "/ping"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 10
+          failureThreshold: 5
         readinessProbe:
           httpGet:
             path: "/ping"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
-          timeoutSeconds: 1
+          timeoutSeconds: 10
+          failureThreshold: 5
       initContainers:
       - name: wait-for-services
         image: busybox


### PR DESCRIPTION
Increased probe timeouts, initialDelaySeconds and failureThreshold count to make sure controller comes up.